### PR TITLE
Enhance pricing component parsing and UI handling for Multi-AZ instances

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -189,6 +189,10 @@ def display_rds_table(rds_instances, metrics, pricing, ri_matches=None):
                     total_price = price_info
                     ri_savings = 0
                     display_name = base_display_name
+            else:
+                # Handle case when price_info is None
+                ri_savings = 0
+                display_name = base_display_name
             
             # For Multi-AZ instances, double the instance price (AWS charges 2x for Multi-AZ)
             if is_multi_az and instance_price is not None and isinstance(instance_price, (int, float)):


### PR DESCRIPTION
- Updated `parse_pricing_components_v2` function to include an `is_multi_az` parameter for better handling of pricing data based on deployment type.
- Added logic to filter pricing based on Multi-AZ vs Single-AZ deployment options.
- Modified `display_rds_table` to handle cases where price information may be None, ensuring proper display of RDS instance pricing.

## Description
Closes #25 
